### PR TITLE
Test-TargetResource fails if there is an app that has some wildcard chars.

### DIFF
--- a/DSCResources/cApplication/cApplication.psm1
+++ b/DSCResources/cApplication/cApplication.psm1
@@ -676,9 +676,9 @@ function Get-InstalledProgram {
     }
 
     $local:InstalledPrograms = @()
-    $local:InstalledPrograms += Get-ChildItem $UninstallRegMachine | ForEach-Object { Get-ItemProperty $_.PSPath } | Where-Object { $_.DisplayName }
+    $local:InstalledPrograms += Get-ChildItem $UninstallRegMachine | ForEach-Object { Get-ItemProperty -LiteralPath $_.PSPath } | Where-Object { $_.DisplayName }
     if (Test-Path $UninstallRegUser) {
-        $local:InstalledPrograms += Get-ChildItem $UninstallRegUser | ForEach-Object { Get-ItemProperty $_.PSPath } | Where-Object { $_.DisplayName }
+        $local:InstalledPrograms += Get-ChildItem $UninstallRegUser | ForEach-Object { Get-ItemProperty -LiteralPath $_.PSPath } | Where-Object { $_.DisplayName }
     }
 
     switch ($PsCmdlet.ParameterSetName) {


### PR DESCRIPTION
Fix #8